### PR TITLE
Check for directory existence and create if absent

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ function renderLESS(input, output) {
         encoding: 'utf-8'
     });
 
+    var outputDir = path.dirname(output);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir);
+    }
+
     less.render(lessinput, {
         paths: [
             path.dirname(input)


### PR DESCRIPTION
For multi-lingual books (e.g. book/en, book/fr, etc.) if you try and
build styles written in LESS it will fail because the init hook
triggers before the language directories are written. This change
checks to see if the path exists first and, if it doesn't, creates it
synchronously.